### PR TITLE
Update the Khronos sample assets url

### DIFF
--- a/examples/src/Main.elm
+++ b/examples/src/Main.elm
@@ -27,7 +27,7 @@ init () ( spa, spaCmd ) =
     , Cmd.batch
         [ spaCmd
         , Http.get
-            { url = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/model-index.Khronos.json"
+            { url = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/model-index.json"
             , expect = Http.expectJson SampleAssetsReceived SampleAssets.decoder
             }
         ]


### PR DESCRIPTION
The Khronos sample assets json has been renamed.

When revisiting the sample asset viewer at https://elm-gltf.mika.xyz/default/IridescentDishWithOlives I got an empty page with "Error" in it, due to a 404 response to https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/model-index.Khronos.json.

It seems to have been renamed to https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/model-index.json

I enthusiastically forked to be able to test it out and provide you with a pull request, but building the example was a bit trickier than anticipated, so I wasn't able to test the new url. However, from inspecting in the browser the format seems the same, and the paths of SampleAssets.toUrl seem to work as before.